### PR TITLE
Bug 1285834: Enable Bluedroid CAF extensions

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -27,6 +27,7 @@ BOARD_BLUETOOTH_DOES_NOT_USE_RFKILL := true
 BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := \
   device/zte/zte_p821a10/bluetooth \
   hardware/libhardware_moz/include/hardware_moz/bluetooth/bluedroid
+BOARD_BLUETOOTH_BDROID_USE_CAF_EXTENSIONS := true
 
 # Appareil photo / enregistrement vidéo
 TARGET_USES_ION := true


### PR DESCRIPTION
Set BOARD_BLUETOOTH_BDROID_USE_CAF_EXTENSIONS to true to be able to use
bluedroid and libhardware from CAF and get Bluetooth to work.
